### PR TITLE
fixed unsafe external links using rel="noopener"

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,10 @@
             <p>Joe Lindie.</p>
             <p>Lead UI Developer</p>
             <span class="button">
-              <a href="https://github.com/Joe-Lindie" target="_blank"
+              <a
+                href="https://github.com/Joe-Lindie"
+                target="_blank"
+                rel="noopener"
                 >Contact Joe</a
               >
             </span>
@@ -76,7 +79,10 @@
             <p>Alex Perez-Davies.</p>
             <p>Lead UX Designer</p>
             <span class="button">
-              <a href="https://github.com/AlexPD93" target="_blank"
+              <a
+                href="https://github.com/AlexPD93"
+                target="_blank"
+                rel="noopener"
                 >Contact Alex</a
               >
             </span>
@@ -145,8 +151,13 @@
     <footer>
       <p>
         &copy; Created by
-        <a href="https://github.com/AlexPD93" target="_blank">Alex</a> &
-        <a href="https://github.com/Joe-Lindie" target="_blank">Joe</a>
+        <a href="https://github.com/AlexPD93" target="_blank" rel="noopener"
+          >Alex</a
+        >
+        &
+        <a href="https://github.com/Joe-Lindie" target="_blank" rel="noopener"
+          >Joe</a
+        >
       </p>
     </footer>
     <script src="script.js"></script>


### PR DESCRIPTION
I fixed unsafe external links using rel="noopener" next to target_blank (open in new tab). Oli posted an interesting article if you want to give it a read. 